### PR TITLE
Prepare Version 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.1
-- `com.jfrog.artifactory` version `4.27.1`.
-- `guava` version `31.1-jre`.
--  `spek-dsl-jvm` version `2.0.18`.
-- `spek-runner-junit5` version `2.0.18`.
-
-## 0.7.0
+## 0.7.2
 - Additional test coverage for implicit type-based value comparisons.
 - Added implicit type-based value comparisons for Temporal types.
 - Removed unused `offsetDatetimeFormatter` from config.
 - Removed `objectMapper` from config since it's no longer needed for logging purposes.
+- `com.jfrog.artifactory` version `4.27.1`.
+- `guava` version `31.1-jre`.
+-  `spek-dsl-jvm` version `2.0.18`.
+- `spek-runner-junit5` version `2.0.18`.
 
 ## 0.6.3
 - `com.jfrog.artifactory` version `4.25.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1
+- `com.jfrog.artifactory` version `4.27.1`.
+- `guava` version `31.1-jre`.
+-  `spek-dsl-jvm` version `2.0.18`.
+- `spek-runner-junit5` version `2.0.18`.
+
 ## 0.7.0
 - Additional test coverage for implicit type-based value comparisons.
 - Added implicit type-based value comparisons for Temporal types.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of declarative, configurable and composable matchers for [Spek2](ht
 ## How to use
 
 ```kotlin
-implementation("io.taff:spek-expekt:0.6.4")
+implementation("io.taff:spek-expekt:0.7.1")
 ```
 
 ### Using the Specification DSL 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of declarative, configurable and composable matchers for [Spek2](ht
 ## How to use
 
 ```kotlin
-implementation("io.taff:spek-expekt:0.7.1")
+implementation("io.taff:spek-expekt:0.7.2")
 ```
 
 ### Using the Specification DSL 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "io.taff"
-version = "0.7.0${ if (isReleaseBuild()) "" else "-SNAPSHOT" }"
+version = "0.7.2${ if (isReleaseBuild()) "" else "-SNAPSHOT" }"
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {


### PR DESCRIPTION
- Additional test coverage for implicit type-based value comparisons.
- Added implicit type-based value comparisons for Temporal types.
- Removed unused `offsetDatetimeFormatter` from config.
- Removed `objectMapper` from config since it's no longer needed for logging purposes.
- `com.jfrog.artifactory` version `4.27.1`.
- `guava` version `31.1-jre`.
-  `spek-dsl-jvm` version `2.0.18`.
- `spek-runner-junit5` version `2.0.18`.